### PR TITLE
新增广州大学信息，请求合并

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -1,3 +1,4 @@
 学校,所在学院,URL
 中山大学南方学院,文学与传媒学院,http://wcy.nfu.edu.cn/a/xueyuangaikuang/zhuanyeshezhi/wangluoyuxinmeitix/
 西安外国语大学,文学与传媒学院,https://xwxy.xisu.edu.cn/info/1022/3323.htm
+暨南大学,新闻与传媒学院,https://xwxy.jnu.edu.cn/


### PR DESCRIPTION
学校,所在学院,URL
广州大学,新闻与传播学院,http://xw.gzhu.edu.cn/ssjg.jsp?wbtreeid=1001
